### PR TITLE
Ensure map gen is consistent with tile gen

### DIFF
--- a/scripts/gfx-process.py
+++ b/scripts/gfx-process.py
@@ -205,7 +205,7 @@ def ClosestColorOf16(LuvColor, CocoPalette, PaletteColorset):
     BestDist = -1
     for i in range(16):
         IDistCMP = Vector3Distance(LuvColor, PaletteColorset[CocoPalette[i]])
-        if BestIdx == None or IDistCMP <= BestDist:
+        if BestIdx == None or IDistCMP < BestDist:
             BestIdx = i
             BestDist = IDistCMP
     return BestIdx


### PR DESCRIPTION
Fixes a problem when the base tile image has fewer than 16 colors. This would result in a problem in which palette color 63 would be in multiple slots and the tile generator would accept the first slot but the map generator would prefer the last slot.
